### PR TITLE
Allow for setting the target for 'link' elements.

### DIFF
--- a/revelator/__init__.py
+++ b/revelator/__init__.py
@@ -221,8 +221,14 @@ class Deck(object):
                        end_key = "\n</pre></code>\n"
 
                    elif k == 'link':
-                       (name, link) = v
-                       start_key = "<p><a href='%s' %s>\n" % (link, self.defaults['frag_class'])
+                       # backward compat for existing decks
+                       try:
+                           (name, link, target) = v
+                       except:
+                           (name, link) = v
+                           target = '_self'
+
+                       start_key = "<p><a href='%s' target='%s' %s>\n" % (link, target, self.defaults['frag_class'])
                        end_key = "\n</a></p>\n"
                        value = name
 

--- a/test.yml
+++ b/test.yml
@@ -88,7 +88,7 @@ slides:
    - 
      - h3: Links and images
      - image: 'https://pbs.twimg.com/profile_images/422168535/51035561796_N01_bigger.jpg'
-     - link: [ 'Ansible Docs', 'http://docs.ansible.com' ]
+     - link: [ 'Ansible Docs', 'http://docs.ansible.com', '_blank' ]
      - link: [ 'Galaxy', 'http://galaxy.ansibleworks.com' ]
    
    - set_global:


### PR DESCRIPTION
Sometimes it's better not to open a link in the same window but instead open a new tab/window.
This would break existing link elements though, is there a way that 'target' could default to '_self' if it's not set?